### PR TITLE
Improve UI with Apple-style design

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Rogue Chess</title>
+  <meta name="theme-color" content="#ffffff">
+  <meta name="apple-mobile-web-app-capable" content="yes">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,40 +1,61 @@
 body {
-  font-family: sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  background: linear-gradient(180deg, #fdfdfd, #efefef);
+  color: #333;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 20px;
+  padding-top: 40px;
+  margin: 0;
+}
+
+h1 {
+  margin-bottom: 24px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: #111;
 }
 
 .board {
   display: grid;
-  grid-template-columns: repeat(8, 60px);
-  grid-template-rows: repeat(8, 60px);
+  grid-template-columns: repeat(8, 64px);
+  grid-template-rows: repeat(8, 64px);
   gap: 0;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  border: 1px solid #d1d1d6;
+  background-color: #fff;
 }
 
 .cell {
-  width: 60px;
-  height: 60px;
+  width: 64px;
+  height: 64px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 36px;
+  font-size: 40px;
   cursor: pointer;
+  transition: background-color 0.2s ease;
+  user-select: none;
 }
 
 .white {
-  background-color: #eee;
+  background-color: #f0f0f3;
 }
 
 .black {
-  background-color: #999;
+  background-color: #c7c7cc;
 }
 
 .highlight {
-  background-color: yellow;
+  background-color: #007aff;
+  color: #fff;
 }
 
 #status {
-  margin-top: 10px;
+  margin-top: 16px;
+  font-weight: 500;
+  font-size: 18px;
 }


### PR DESCRIPTION
## Summary
- modernize the chess demo UI to match a sleek apple-inspired design
- add meta tags for theme color and web-app capability
- restyle layout, board and pieces with soft colors and shadows

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68491412afac83279eb4f3feb089a14e