### PR TITLE
Fix background height in docs

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -8,6 +8,7 @@ body {
   align-items: center;
   padding-top: 40px;
   margin: 0;
+  min-height: 100vh;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- ensure the body element stretches to the full viewport height

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6849197962d08327b90ee0b6112aa017