### PR TITLE
Fix CDN loading issues for 3D board

### DIFF
--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -6,10 +6,10 @@
   <title>3D Chess v2</title>
   <link rel="stylesheet" href="style.css">
   <!-- Three.js library -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/js/controls/OrbitControls.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
   <!-- chess.js for chess logic -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.13.4/chess.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chess.js@0.13.4/chess.min.js"></script>
 </head>
 <body>
   <div id="container"></div>


### PR DESCRIPTION
## Summary
- remove bundled libs under docs/v2
- use CDN links again for three.js, OrbitControls, and chess.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68491b57c87483278b0f2cc3430aefd9