### PR TITLE
Fix CDN chess.js path for v2

### DIFF
--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -9,7 +9,8 @@
   <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
   <!-- chess.js for chess logic -->
-  <script src="https://cdn.jsdelivr.net/npm/chess.js@0.13.4/chess.min.js"></script>
+  <!-- use the UMD build so the global `Chess` variable is available -->
+  <script src="https://cdn.jsdelivr.net/npm/chess.js@0.13.4/dist/chess.min.js"></script>
 </head>
 <body>
   <div id="container"></div>


### PR DESCRIPTION
## Summary
- fix v2 demo so the `Chess` global loads correctly by using the UMD build

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68491ff04ab88327825f8ce3190c4cc9