### PR TITLE
Improve captured pieces display

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,16 @@
 <body>
   <h1>Basic Chess</h1>
   <div id="board" class="board"></div>
+  <div id="captures" class="captures">
+    <div class="capture-group">
+      <div class="capture-label">White Score: <span id="white-score">0</span></div>
+      <div id="white-captured" class="captured-pieces"></div>
+    </div>
+    <div class="capture-group">
+      <div class="capture-label">Black Score: <span id="black-score">0</span></div>
+      <div id="black-captured" class="captured-pieces"></div>
+    </div>
+  </div>
   <div id="status"></div>
   <script src="main.js"></script>
 </body>

--- a/docs/main.js
+++ b/docs/main.js
@@ -177,8 +177,11 @@ class Board {
     const moves = piece.possibleMoves(this, fromX, fromY);
     const valid = moves.some(([mx, my]) => mx === toX && my === toY);
     if (!valid) return false;
+
+    let captured = this.piece(toX, toY);
     // handle en passant
     if (piece.type === 'p' && this.enPassant && toX === this.enPassant[0] && toY === this.enPassant[1]) {
+      captured = this.piece(fromX, toY);
       this.grid[fromX][toY] = null; // capture pawn
     }
     // handle castling
@@ -216,7 +219,7 @@ class Board {
       if (fromY === 0) this.castling[piece.color].Q = false;
       if (fromY === 7) this.castling[piece.color].K = false;
     }
-    return true;
+    return captured;
   }
 }
 
@@ -225,6 +228,7 @@ class Game {
     this.board = new Board();
     this.turn = 'w';
     this.selected = null; // [x, y]
+    this.captured = { w: [], b: [] };
     this.render();
   }
 
@@ -246,6 +250,7 @@ class Game {
       }
     }
     this.updateStatus();
+    this.updateCaptured();
   }
 
   symbol(piece) {
@@ -260,11 +265,18 @@ class Game {
     return symbols[piece.type][piece.color];
   }
 
+  pieceValue(type) {
+    const values = { p: 1, n: 3, b: 3, r: 5, q: 9, k: 0 };
+    return values[type] || 0;
+  }
+
   clickCell(e) {
     const x = parseInt(e.currentTarget.dataset.x);
     const y = parseInt(e.currentTarget.dataset.y);
     if (this.selected) {
-      if (this.board.movePiece(this.selected[0], this.selected[1], x, y)) {
+      const captured = this.board.movePiece(this.selected[0], this.selected[1], x, y);
+      if (captured !== false) {
+        if (captured) this.captured[this.turn].push(captured);
         this.turn = this.turn === 'w' ? 'b' : 'w';
       }
       this.selected = null;
@@ -290,6 +302,17 @@ class Game {
 
   updateStatus() {
     document.getElementById('status').textContent = this.turn === 'w' ? "White's move" : "Black's move";
+  }
+
+  updateCaptured() {
+    ['w','b'].forEach(color => {
+      const el = document.getElementById(color === 'w' ? 'white-captured' : 'black-captured');
+      el.innerHTML = this.captured[color]
+        .map(p => `<span class="captured-piece">${this.symbol(p)}</span>`)
+        .join('');
+      const score = this.captured[color].reduce((s,p)=>s+this.pieceValue(p.type),0);
+      document.getElementById(color === 'w' ? 'white-score' : 'black-score').textContent = score;
+    });
   }
 }
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -60,3 +60,38 @@ h1 {
   font-weight: 500;
   font-size: 18px;
 }
+
+.captures {
+  display: flex;
+  gap: 24px;
+  margin-top: 20px;
+}
+
+.capture-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #d1d1d6;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  padding: 8px 12px;
+  border-radius: 8px;
+  min-width: 140px;
+}
+
+.capture-label {
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.captured-pieces {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 4px;
+  min-height: 28px;
+}
+
+.captured-piece {
+  font-size: 24px;
+}


### PR DESCRIPTION
## Summary
- restyle capture boxes with borders and shadows
- render each captured piece as a separate span
- show score label without parentheses

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_684baf6637b88327996e7abbd10d81cd